### PR TITLE
fix: pin crossplane constraint to >=v1.20 and upgrade up/xp clis

### DIFF
--- a/functions/upbox/main.k
+++ b/functions/upbox/main.k
@@ -13,6 +13,19 @@ _metadata = lambda name: str -> any {
 
 id = "upbox-{}-{}".format(oxr.spec.parameters.company, oxr.metadata.name)
 
+# Root volume per instance size. The AMI ships a 20Gi root device, so micro and
+# small inherit it and the larger sizes grow it at launch. Bigger boxes are used
+# for work that fills a disk: building function images and running local dev
+# control planes both leave multi-gigabyte layers behind.
+_root_volume_sizes = {
+    micro = 20
+    small = 20
+    medium = 40
+    large = 60
+    xlarge = 60
+}
+_root_volume_size = _root_volume_sizes[oxr.spec.parameters.size] or 20
+
 _api_key = oxr.spec.parameters?.anthropicApiKey or ""
 _extra_keys = oxr.spec.parameters?.additionalPublicKeys or []
 
@@ -112,6 +125,10 @@ if _vpc:
                     }
                     ami = oxr.spec.parameters.amiId
                     keyName = id
+                    rootBlockDevice = [{
+                        volumeSize = _root_volume_size
+                        volumeType = "gp3"
+                    }]
                     tags = {
                         Name = id
                     }

--- a/packer/upbox.pkr.hcl
+++ b/packer/upbox.pkr.hcl
@@ -75,8 +75,8 @@ build {
   provisioner "shell" {
     environment_vars = [
       "SSH_USER=ubuntu",
-      "UP_CLI_VERSION=v0.39.0",
-      "XP_CLI_VERSION=v1.19.1",
+      "UP_CLI_VERSION=v0.53.1",
+      "XP_CLI_VERSION=v2.4.1",
 
       "DOCKER_VERSION=5:28.0.4-1~ubuntu.24.04~noble",
       "CONTAINERD_VERSION=1.7.27-1",

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -3,6 +3,8 @@ kind: Project
 metadata:
   name: configuration-upbox
 spec:
+  crossplane:
+    version: '>=v1.20.0 || >=v2.0.0-rc.0'
   dependsOn:
   - apiVersion: pkg.crossplane.io/v1
     kind: Configuration


### PR DESCRIPTION
### Description of your changes

Added disk root volume per instance size [micro/small=20;medium=40;large/xlarge=60].
The newer up cli version during the `up project build` injects a default constraint of `>=v2.0.0-rc.0` into the generated `Configuration` meta.


To fix:
- Pin the package's Crossplane version constraint in `upbound.yaml`: `spec.crossplane.version: '>=v1.20.0 || >=v2.0.0-rc.0'`
- Bump AMI toolchain in `packer/upbox.pkr.hcl`:
    - `UP_CLI_VERSION` v0.39.0 -> v0.53.1
    - `XP_CLI_VERSION` v1.19.1 -> v2.4.1